### PR TITLE
Lower the requirements for .NET Framework

### DIFF
--- a/src/Actress/Actress.csproj
+++ b/src/Actress/Actress.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net452;net462</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -16,7 +16,6 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/kthompson/Actress.git</RepositoryUrl>
   </PropertyGroup>
-    
 
   <!-- Conditionally obtain references for the .NET Framework 4.5 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/Actress/Actress.csproj
+++ b/src/Actress/Actress.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net452;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -16,13 +16,4 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/kthompson/Actress.git</RepositoryUrl>
   </PropertyGroup>
-
-  <!-- Conditionally obtain references for the .NET Framework 4.5 target -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Reference Include="System.Threading.Tasks" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <Reference Include="System.Threading.Tasks" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
We use this package (v0.1.0) in a .NET 4.5 app, and today I noticed that v0.2.0 doesn't support `net45` anymore.

The `net452` and `net462` target frameworks can be removed as well, because libs or apps targeting these can use the `net45` assemblies. Should I do this change?